### PR TITLE
:tada: Build diff of Dockerfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,66 +2,52 @@ os:
   - linux
 env:
   matrix:
-    - TAG=latest                    OS=alpine:3.5     OPAM=1.2.2 OCAML=4.04.1
-    - TAG=alpine3.5_ocaml4.06.0     OS=alpine:3.5     OPAM=1.2.2 OCAML=4.06.0+trunk
-    - TAG=alpine3.5_ocaml4.05.0     OS=alpine:3.5     OPAM=1.2.2 OCAML=4.05.0+trunk
-    - TAG=alpine3.5_ocaml4.04.1     OS=alpine:3.5     OPAM=1.2.2 OCAML=4.04.1
-    - TAG=alpine3.5_ocaml4.03.0     OS=alpine:3.5     OPAM=1.2.2 OCAML=4.03.0
-    - TAG=alpine3.5_ocaml4.02.3     OS=alpine:3.5     OPAM=1.2.2 OCAML=4.02.3
-    - TAG=alpine3.5_ocaml4.01.0     OS=alpine:3.5     OPAM=1.2.2 OCAML=4.01.0
-    - TAG=alpine3.5_ocaml4.00.1     OS=alpine:3.5     OPAM=1.2.2 OCAML=4.00.1
-    - TAG=centos7_ocaml4.06.0       OS=centos:7       OPAM=1.2.2 OCAML=4.06.0+trunk
-    - TAG=centos7_ocaml4.05.0       OS=centos:7       OPAM=1.2.2 OCAML=4.05.0+trunk
-    - TAG=centos7_ocaml4.04.1       OS=centos:7       OPAM=1.2.2 OCAML=4.04.1
-    - TAG=centos7_ocaml4.03.0       OS=centos:7       OPAM=1.2.2 OCAML=4.03.0
-    - TAG=centos7_ocaml4.02.3       OS=centos:7       OPAM=1.2.2 OCAML=4.02.3
-    - TAG=centos7_ocaml4.01.0       OS=centos:7       OPAM=1.2.2 OCAML=4.01.0
-    - TAG=centos7_ocaml4.00.1       OS=centos:7       OPAM=1.2.2 OCAML=4.00.1
-    - TAG=centos6_ocaml4.06.0       OS=centos:6       OPAM=1.2.2 OCAML=4.06.0+trunk
-    - TAG=centos6_ocaml4.05.0       OS=centos:6       OPAM=1.2.2 OCAML=4.05.0+trunk
-    - TAG=centos6_ocaml4.04.1       OS=centos:6       OPAM=1.2.2 OCAML=4.04.1
-    - TAG=centos6_ocaml4.03.0       OS=centos:6       OPAM=1.2.2 OCAML=4.03.0
-    - TAG=centos6_ocaml4.02.3       OS=centos:6       OPAM=1.2.2 OCAML=4.02.3
-    - TAG=centos6_ocaml4.01.0       OS=centos:6       OPAM=1.2.2 OCAML=4.01.0
-    - TAG=centos6_ocaml4.00.1       OS=centos:6       OPAM=1.2.2 OCAML=4.00.1
-    - TAG=debian8_ocaml4.06.0       OS=debian:8       OPAM=1.2.2 OCAML=4.06.0+trunk
-    - TAG=debian8_ocaml4.05.0       OS=debian:8       OPAM=1.2.2 OCAML=4.05.0+trunk
-    - TAG=debian8_ocaml4.04.1       OS=debian:8       OPAM=1.2.2 OCAML=4.04.1
-    - TAG=debian8_ocaml4.03.0       OS=debian:8       OPAM=1.2.2 OCAML=4.03.0
-    - TAG=debian8_ocaml4.02.3       OS=debian:8       OPAM=1.2.2 OCAML=4.02.3
-    - TAG=debian8_ocaml4.01.0       OS=debian:8       OPAM=1.2.2 OCAML=4.01.0
-    - TAG=debian8_ocaml4.00.1       OS=debian:8       OPAM=1.2.2 OCAML=4.00.1
-    - TAG=ubuntu16.04_ocaml4.06.0   OS=ubuntu:16.04   OPAM=1.2.2 OCAML=4.06.0+trunk
-    - TAG=ubuntu16.04_ocaml4.05.0   OS=ubuntu:16.04   OPAM=1.2.2 OCAML=4.05.0+trunk
-    - TAG=ubuntu16.04_ocaml4.04.1   OS=ubuntu:16.04   OPAM=1.2.2 OCAML=4.04.1
-    - TAG=ubuntu16.04_ocaml4.03.0   OS=ubuntu:16.04   OPAM=1.2.2 OCAML=4.03.0
-    - TAG=ubuntu16.04_ocaml4.02.3   OS=ubuntu:16.04   OPAM=1.2.2 OCAML=4.02.3
-    - TAG=ubuntu16.04_ocaml4.01.0   OS=ubuntu:16.04   OPAM=1.2.2 OCAML=4.01.0
-    - TAG=ubuntu16.04_ocaml4.00.1   OS=ubuntu:16.04   OPAM=1.2.2 OCAML=4.00.1
+    - TAG=alpine3.5_ocaml4.06.0   OS=alpine:3.5   OPAM=1.2.2 OCAML=4.06.0+trunk ALIAS='alpine_ocaml4.06.0 4.06.0'
+    - TAG=alpine3.5_ocaml4.05.0   OS=alpine:3.5   OPAM=1.2.2 OCAML=4.05.0+trunk ALIAS='alpine_ocaml4.05.0 4.05.0'
+    - TAG=alpine3.5_ocaml4.04.1   OS=alpine:3.5   OPAM=1.2.2 OCAML=4.04.1       ALIAS='alpine_ocaml4.04.1 4.04.1 latest'
+    - TAG=alpine3.5_ocaml4.03.0   OS=alpine:3.5   OPAM=1.2.2 OCAML=4.03.0       ALIAS='alpine_ocaml4.03.0 4.03.0'
+    - TAG=alpine3.5_ocaml4.02.3   OS=alpine:3.5   OPAM=1.2.2 OCAML=4.02.3       ALIAS='alpine_ocaml4.02.3 4.02.3'
+    - TAG=alpine3.5_ocaml4.01.0   OS=alpine:3.5   OPAM=1.2.2 OCAML=4.01.0       ALIAS='alpine_ocaml4.01.0 4.01.0'
+    - TAG=alpine3.5_ocaml4.00.1   OS=alpine:3.5   OPAM=1.2.2 OCAML=4.00.1       ALIAS='alpine_ocaml4.00.1 4.00.1'
+    - TAG=centos7_ocaml4.06.0     OS=centos:7     OPAM=1.2.2 OCAML=4.06.0+trunk ALIAS='centos_ocaml4.06.0'
+    - TAG=centos7_ocaml4.05.0     OS=centos:7     OPAM=1.2.2 OCAML=4.05.0+trunk ALIAS='centos_ocaml4.05.0'
+    - TAG=centos7_ocaml4.04.1     OS=centos:7     OPAM=1.2.2 OCAML=4.04.1       ALIAS='centos_ocaml4.04.1'
+    - TAG=centos7_ocaml4.03.0     OS=centos:7     OPAM=1.2.2 OCAML=4.03.0       ALIAS='centos_ocaml4.03.0'
+    - TAG=centos7_ocaml4.02.3     OS=centos:7     OPAM=1.2.2 OCAML=4.02.3       ALIAS='centos_ocaml4.02.3'
+    - TAG=centos7_ocaml4.01.0     OS=centos:7     OPAM=1.2.2 OCAML=4.01.0       ALIAS='centos_ocaml4.01.0'
+    - TAG=centos7_ocaml4.00.1     OS=centos:7     OPAM=1.2.2 OCAML=4.00.1       ALIAS='centos_ocaml4.00.1'
+    - TAG=centos6_ocaml4.06.0     OS=centos:6     OPAM=1.2.2 OCAML=4.06.0+trunk ALIAS=''
+    - TAG=centos6_ocaml4.05.0     OS=centos:6     OPAM=1.2.2 OCAML=4.05.0+trunk ALIAS=''
+    - TAG=centos6_ocaml4.04.1     OS=centos:6     OPAM=1.2.2 OCAML=4.04.1       ALIAS=''
+    - TAG=centos6_ocaml4.03.0     OS=centos:6     OPAM=1.2.2 OCAML=4.03.0       ALIAS=''
+    - TAG=centos6_ocaml4.02.3     OS=centos:6     OPAM=1.2.2 OCAML=4.02.3       ALIAS=''
+    - TAG=centos6_ocaml4.01.0     OS=centos:6     OPAM=1.2.2 OCAML=4.01.0       ALIAS=''
+    - TAG=centos6_ocaml4.00.1     OS=centos:6     OPAM=1.2.2 OCAML=4.00.1       ALIAS=''
+    - TAG=debian8_ocaml4.06.0     OS=debian:8     OPAM=1.2.2 OCAML=4.06.0+trunk ALIAS='debian_ocaml4.06.0'
+    - TAG=debian8_ocaml4.05.0     OS=debian:8     OPAM=1.2.2 OCAML=4.05.0+trunk ALIAS='debian_ocaml4.05.0'
+    - TAG=debian8_ocaml4.04.1     OS=debian:8     OPAM=1.2.2 OCAML=4.04.1       ALIAS='debian_ocaml4.04.1'
+    - TAG=debian8_ocaml4.03.0     OS=debian:8     OPAM=1.2.2 OCAML=4.03.0       ALIAS='debian_ocaml4.03.0'
+    - TAG=debian8_ocaml4.02.3     OS=debian:8     OPAM=1.2.2 OCAML=4.02.3       ALIAS='debian_ocaml4.02.3'
+    - TAG=debian8_ocaml4.01.0     OS=debian:8     OPAM=1.2.2 OCAML=4.01.0       ALIAS='debian_ocaml4.01.0'
+    - TAG=debian8_ocaml4.00.1     OS=debian:8     OPAM=1.2.2 OCAML=4.00.1       ALIAS='debian_ocaml4.00.1'
+    - TAG=ubuntu16.04_ocaml4.06.0 OS=ubuntu:16.04 OPAM=1.2.2 OCAML=4.06.0+trunk ALIAS='ubuntu_ocaml4.06.0'
+    - TAG=ubuntu16.04_ocaml4.05.0 OS=ubuntu:16.04 OPAM=1.2.2 OCAML=4.05.0+trunk ALIAS='ubuntu_ocaml4.05.0'
+    - TAG=ubuntu16.04_ocaml4.04.1 OS=ubuntu:16.04 OPAM=1.2.2 OCAML=4.04.1       ALIAS='ubuntu_ocaml4.04.1'
+    - TAG=ubuntu16.04_ocaml4.03.0 OS=ubuntu:16.04 OPAM=1.2.2 OCAML=4.03.0       ALIAS='ubuntu_ocaml4.03.0'
+    - TAG=ubuntu16.04_ocaml4.02.3 OS=ubuntu:16.04 OPAM=1.2.2 OCAML=4.02.3       ALIAS='ubuntu_ocaml4.02.3'
+    - TAG=ubuntu16.04_ocaml4.01.0 OS=ubuntu:16.04 OPAM=1.2.2 OCAML=4.01.0       ALIAS='ubuntu_ocaml4.01.0'
+    - TAG=ubuntu16.04_ocaml4.00.1 OS=ubuntu:16.04 OPAM=1.2.2 OCAML=4.00.1       ALIAS='ubuntu_ocaml4.00.1'
 
 language: c
 sudo: required
+cache: apt
 
 services:
   - docker
 
-before_install:
+install:
   - sudo apt-get update
   - sudo apt-get install -y -q -o Dpkg::Options::="--force-confnew" docker-engine
 
-install:
-  - ./generate.sh > Dockerfile
-  - docker build -t akabe/ocaml:$TAG .
-  - docker history --no-trunc akabe/ocaml:$TAG
-
 script:
-  - docker run --rm -v $PWD:$PWD -w $PWD/tests akabe/ocaml:$TAG sh run_test.sh
-
-after_success:
-  - |-
-    if [[ "$TRAVIS_PULL_REQUEST" == false ]] && [[ "$TRAVIS_BRANCH" == master ]]; then
-      docker login -u $DOCKER_USER -p $DOCKER_PWD
-      docker push akabe/ocaml:$TAG
-    else
-      echo -e "\033[33mSkip deploying image to DockerHub...\033[0m"
-    fi
+  - bash -eu travis-ci.sh

--- a/README.md
+++ b/README.md
@@ -32,63 +32,98 @@ val fact : int -> int = <fun>
 
 ## Distributions
 
-The default `latest` version is the following distribution:
+The default images are built on Alpine 3.5:
 
-| Distribution | OCaml | OPAM | Command |
-| ------------ | ----- | ---- | ------- |
-| Alpine 3.5 | 4.04.1 | 1.2.2 | `docker pull akabe/ocaml` |
+| Tag | OCaml | OPAM | Command | Dockerfile |
+| ------------ | ----- | ---- | ------- | ---------- |
+| **latest** | 4.04.1 | 1.2.2 | `docker pull akabe/ocaml` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.04.1/Dockerfile) |
+| 4.06.0 | 4.06.0+trunk | 1.2.2 | `docker pull akabe/ocaml:4.06.0` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.06.0/Dockerfile) |
+| 4.05.0 | 4.05.0+trunk | 1.2.2 | `docker pull akabe/ocaml:4.05.0` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.05.0/Dockerfile) |
+| 4.04.1 | 4.04.1 | 1.2.2 | `docker pull akabe/ocaml:4.04.1` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.04.1/Dockerfile) |
+| 4.03.0 | 4.03.0 | 1.2.2 | `docker pull akabe/ocaml:4.03.0` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.03.0/Dockerfile) |
+| 4.02.3 | 4.02.3 | 1.2.2 | `docker pull akabe/ocaml:4.02.3` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.02.3/Dockerfile) |
+| 4.01.0 | 4.01.0 | 1.2.2 | `docker pull akabe/ocaml:4.01.0` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.01.0/Dockerfile) |
+| 4.00.1 | 4.00.1 | 1.2.2 | `docker pull akabe/ocaml:4.00.1` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.00.1/Dockerfile) |
 
 ### Alpine
 
-| Distribution | OCaml | OPAM | Command |
-| ------------ | ----- | ---- | ------- |
-| Alpine 3.5 | 4.06.0+trunk | 1.2.2 | `docker pull akabe/ocaml:alpine3.5_ocaml4.06.0` |
-| Alpine 3.5 | 4.05.0+trunk | 1.2.2 | `docker pull akabe/ocaml:alpine3.5_ocaml4.05.0` |
-| Alpine 3.5 | 4.04.1 | 1.2.2 | `docker pull akabe/ocaml:alpine3.5_ocaml4.04.1` |
-| Alpine 3.5 | 4.03.0 | 1.2.2 | `docker pull akabe/ocaml:alpine3.5_ocaml4.03.0` |
-| Alpine 3.5 | 4.02.3 | 1.2.2 | `docker pull akabe/ocaml:alpine3.5_ocaml4.02.3` |
-| Alpine 3.5 | 4.01.0 | 1.2.2 | `docker pull akabe/ocaml:alpine3.5_ocaml4.01.0` |
-| Alpine 3.5 | 4.00.1 | 1.2.2 | `docker pull akabe/ocaml:alpine3.5_ocaml4.00.1` |
+| Distribution | OCaml | OPAM | Command | Dockerfile |
+| ------------ | ----- | ---- | ------- | ---------- |
+| Alpine | 4.06.0+trunk | 1.2.2 | `docker pull akabe/ocaml:alpine_ocaml4.06.0` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.06.0/Dockerfile) |
+| Alpine | 4.05.0+trunk | 1.2.2 | `docker pull akabe/ocaml:alpine_ocaml4.05.0` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.05.0/Dockerfile) |
+| Alpine | 4.04.1 | 1.2.2 | `docker pull akabe/ocaml:alpine_ocaml4.04.1` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.04.1/Dockerfile) |
+| Alpine | 4.03.0 | 1.2.2 | `docker pull akabe/ocaml:alpine_ocaml4.03.0` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.03.0/Dockerfile) |
+| Alpine | 4.02.3 | 1.2.2 | `docker pull akabe/ocaml:alpine_ocaml4.02.3` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.02.3/Dockerfile) |
+| Alpine | 4.01.0 | 1.2.2 | `docker pull akabe/ocaml:alpine_ocaml4.01.0` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.01.0/Dockerfile) |
+| Alpine | 4.00.1 | 1.2.2 | `docker pull akabe/ocaml:alpine_ocaml4.00.1` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.00.1/Dockerfile) |
+| Alpine 3.5 | 4.06.0+trunk | 1.2.2 | `docker pull akabe/ocaml:alpine3.5_ocaml4.06.0` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.06.0/Dockerfile) |
+| Alpine 3.5 | 4.05.0+trunk | 1.2.2 | `docker pull akabe/ocaml:alpine3.5_ocaml4.05.0` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.05.0/Dockerfile) |
+| Alpine 3.5 | 4.04.1 | 1.2.2 | `docker pull akabe/ocaml:alpine3.5_ocaml4.04.1` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.04.1/Dockerfile) |
+| Alpine 3.5 | 4.03.0 | 1.2.2 | `docker pull akabe/ocaml:alpine3.5_ocaml4.03.0` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.03.0/Dockerfile) |
+| Alpine 3.5 | 4.02.3 | 1.2.2 | `docker pull akabe/ocaml:alpine3.5_ocaml4.02.3` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.02.3/Dockerfile) |
+| Alpine 3.5 | 4.01.0 | 1.2.2 | `docker pull akabe/ocaml:alpine3.5_ocaml4.01.0` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.01.0/Dockerfile) |
+| Alpine 3.5 | 4.00.1 | 1.2.2 | `docker pull akabe/ocaml:alpine3.5_ocaml4.00.1` | [Dockerfile](dockerfiles/alpine3.5_ocaml4.00.1/Dockerfile) |
 
 ### CentOS
 
-| Distribution | OCaml | OPAM | Command |
-| ------------ | ----- | ---- | ------- |
-| Centos 7 | 4.06.0+trunk | 1.2.2 | `docker pull akabe/ocaml:centos7_ocaml4.06.0` |
-| Centos 7 | 4.05.0+trunk | 1.2.2 | `docker pull akabe/ocaml:centos7_ocaml4.05.0` |
-| Centos 7 | 4.04.1 | 1.2.2 | `docker pull akabe/ocaml:centos7_ocaml4.04.1` |
-| Centos 7 | 4.03.0 | 1.2.2 | `docker pull akabe/ocaml:centos7_ocaml4.03.0` |
-| Centos 7 | 4.02.3 | 1.2.2 | `docker pull akabe/ocaml:centos7_ocaml4.02.3` |
-| Centos 7 | 4.01.0 | 1.2.2 | `docker pull akabe/ocaml:centos7_ocaml4.01.0` |
-| Centos 7 | 4.00.1 | 1.2.2 | `docker pull akabe/ocaml:centos7_ocaml4.00.1` |
-| Centos 6 | 4.06.0+trunk | 1.2.2 | `docker pull akabe/ocaml:centos6_ocaml4.06.0` |
-| Centos 6 | 4.05.0+trunk | 1.2.2 | `docker pull akabe/ocaml:centos6_ocaml4.05.0` |
-| Centos 6 | 4.04.1 | 1.2.2 | `docker pull akabe/ocaml:centos6_ocaml4.04.1` |
-| Centos 6 | 4.03.0 | 1.2.2 | `docker pull akabe/ocaml:centos6_ocaml4.03.0` |
-| Centos 6 | 4.02.3 | 1.2.2 | `docker pull akabe/ocaml:centos6_ocaml4.02.3` |
-| Centos 6 | 4.01.0 | 1.2.2 | `docker pull akabe/ocaml:centos6_ocaml4.01.0` |
-| Centos 6 | 4.00.1 | 1.2.2 | `docker pull akabe/ocaml:centos6_ocaml4.00.1` |
+| Distribution | OCaml | OPAM | Command | Dockerfile |
+| ------------ | ----- | ---- | ------- | ---------- |
+| CentOS | 4.06.0+trunk | 1.2.2 | `docker pull akabe/ocaml:centos_ocaml4.06.0` | [Dockerfile](dockerfiles/centos7_ocaml4.06.0/Dockerfile) |
+| CentOS | 4.05.0+trunk | 1.2.2 | `docker pull akabe/ocaml:centos_ocaml4.05.0` | [Dockerfile](dockerfiles/centos7_ocaml4.05.0/Dockerfile) |
+| CentOS | 4.04.1 | 1.2.2 | `docker pull akabe/ocaml:centos_ocaml4.04.1` | [Dockerfile](dockerfiles/centos7_ocaml4.04.1/Dockerfile) |
+| CentOS | 4.03.0 | 1.2.2 | `docker pull akabe/ocaml:centos_ocaml4.03.0` | [Dockerfile](dockerfiles/centos7_ocaml4.03.0/Dockerfile) |
+| CentOS | 4.02.3 | 1.2.2 | `docker pull akabe/ocaml:centos_ocaml4.02.3` | [Dockerfile](dockerfiles/centos7_ocaml4.02.3/Dockerfile) |
+| CentOS | 4.01.0 | 1.2.2 | `docker pull akabe/ocaml:centos_ocaml4.01.0` | [Dockerfile](dockerfiles/centos7_ocaml4.01.0/Dockerfile) |
+| CentOS | 4.00.1 | 1.2.2 | `docker pull akabe/ocaml:centos_ocaml4.00.1` | [Dockerfile](dockerfiles/centos7_ocaml4.00.1/Dockerfile) |
+| CentOS 7 | 4.06.0+trunk | 1.2.2 | `docker pull akabe/ocaml:centos7_ocaml4.06.0` | [Dockerfile](dockerfiles/centos7_ocaml4.06.0/Dockerfile) |
+| CentOS 7 | 4.05.0+trunk | 1.2.2 | `docker pull akabe/ocaml:centos7_ocaml4.05.0` | [Dockerfile](dockerfiles/centos7_ocaml4.05.0/Dockerfile) |
+| CentOS 7 | 4.04.1 | 1.2.2 | `docker pull akabe/ocaml:centos7_ocaml4.04.1` | [Dockerfile](dockerfiles/centos7_ocaml4.04.1/Dockerfile) |
+| CentOS 7 | 4.03.0 | 1.2.2 | `docker pull akabe/ocaml:centos7_ocaml4.03.0` | [Dockerfile](dockerfiles/centos7_ocaml4.03.0/Dockerfile) |
+| CentOS 7 | 4.02.3 | 1.2.2 | `docker pull akabe/ocaml:centos7_ocaml4.02.3` | [Dockerfile](dockerfiles/centos7_ocaml4.02.3/Dockerfile) |
+| CentOS 7 | 4.01.0 | 1.2.2 | `docker pull akabe/ocaml:centos7_ocaml4.01.0` | [Dockerfile](dockerfiles/centos7_ocaml4.01.0/Dockerfile) |
+| CentOS 7 | 4.00.1 | 1.2.2 | `docker pull akabe/ocaml:centos7_ocaml4.00.1` | [Dockerfile](dockerfiles/centos7_ocaml4.00.1/Dockerfile) |
+| CentOS 6 | 4.06.0+trunk | 1.2.2 | `docker pull akabe/ocaml:centos6_ocaml4.06.0` | [Dockerfile](dockerfiles/centos6_ocaml4.06.0/Dockerfile) |
+| CentOS 6 | 4.05.0+trunk | 1.2.2 | `docker pull akabe/ocaml:centos6_ocaml4.05.0` | [Dockerfile](dockerfiles/centos6_ocaml4.05.0/Dockerfile) |
+| CentOS 6 | 4.04.1 | 1.2.2 | `docker pull akabe/ocaml:centos6_ocaml4.04.1` | [Dockerfile](dockerfiles/centos6_ocaml4.04.1/Dockerfile) |
+| CentOS 6 | 4.03.0 | 1.2.2 | `docker pull akabe/ocaml:centos6_ocaml4.03.0` | [Dockerfile](dockerfiles/centos6_ocaml4.03.0/Dockerfile) |
+| CentOS 6 | 4.02.3 | 1.2.2 | `docker pull akabe/ocaml:centos6_ocaml4.02.3` | [Dockerfile](dockerfiles/centos6_ocaml4.02.3/Dockerfile) |
+| CentOS 6 | 4.01.0 | 1.2.2 | `docker pull akabe/ocaml:centos6_ocaml4.01.0` | [Dockerfile](dockerfiles/centos6_ocaml4.01.0/Dockerfile) |
+| CentOS 6 | 4.00.1 | 1.2.2 | `docker pull akabe/ocaml:centos6_ocaml4.00.1` | [Dockerfile](dockerfiles/centos6_ocaml4.00.1/Dockerfile) |
 
 ### Debian
 
-| Distribution | OCaml | OPAM | Command |
-| ------------ | ----- | ---- | ------- |
-| Debian 8 | 4.06.0+trunk | 1.2.2 | `docker pull akabe/ocaml:debian8_ocaml4.06.0` |
-| Debian 8 | 4.05.0+trunk | 1.2.2 | `docker pull akabe/ocaml:debian8_ocaml4.05.0` |
-| Debian 8 | 4.04.1 | 1.2.2 | `docker pull akabe/ocaml:debian8_ocaml4.04.1` |
-| Debian 8 | 4.03.0 | 1.2.2 | `docker pull akabe/ocaml:debian8_ocaml4.03.0` |
-| Debian 8 | 4.02.3 | 1.2.2 | `docker pull akabe/ocaml:debian8_ocaml4.02.3` |
-| Debian 8 | 4.01.0 | 1.2.2 | `docker pull akabe/ocaml:debian8_ocaml4.01.0` |
-| Debian 8 | 4.00.1 | 1.2.2 | `docker pull akabe/ocaml:debian8_ocaml4.00.1` |
+| Distribution | OCaml | OPAM | Command | Dockerfile |
+| ------------ | ----- | ---- | ------- | ---------- |
+| Debian | 4.06.0+trunk | 1.2.2 | `docker pull akabe/ocaml:debian_ocaml4.06.0` | [Dockerfile](dockerfiles/debian8_ocaml4.06.0/Dockerfile) |
+| Debian | 4.05.0+trunk | 1.2.2 | `docker pull akabe/ocaml:debian_ocaml4.05.0` | [Dockerfile](dockerfiles/debian8_ocaml4.05.0/Dockerfile) |
+| Debian | 4.04.1 | 1.2.2 | `docker pull akabe/ocaml:debian_ocaml4.04.1` | [Dockerfile](dockerfiles/debian8_ocaml4.04.1/Dockerfile) |
+| Debian | 4.03.0 | 1.2.2 | `docker pull akabe/ocaml:debian_ocaml4.03.0` | [Dockerfile](dockerfiles/debian8_ocaml4.03.0/Dockerfile) |
+| Debian | 4.02.3 | 1.2.2 | `docker pull akabe/ocaml:debian_ocaml4.02.3` | [Dockerfile](dockerfiles/debian8_ocaml4.02.3/Dockerfile) |
+| Debian | 4.01.0 | 1.2.2 | `docker pull akabe/ocaml:debian_ocaml4.01.0` | [Dockerfile](dockerfiles/debian8_ocaml4.01.0/Dockerfile) |
+| Debian | 4.00.1 | 1.2.2 | `docker pull akabe/ocaml:debian_ocaml4.00.1` | [Dockerfile](dockerfiles/debian8_ocaml4.00.1/Dockerfile) |
+| Debian 8 | 4.06.0+trunk | 1.2.2 | `docker pull akabe/ocaml:debian8_ocaml4.06.0` | [Dockerfile](dockerfiles/debian8_ocaml4.06.0/Dockerfile) |
+| Debian 8 | 4.05.0+trunk | 1.2.2 | `docker pull akabe/ocaml:debian8_ocaml4.05.0` | [Dockerfile](dockerfiles/debian8_ocaml4.05.0/Dockerfile) |
+| Debian 8 | 4.04.1 | 1.2.2 | `docker pull akabe/ocaml:debian8_ocaml4.04.1` | [Dockerfile](dockerfiles/debian8_ocaml4.04.1/Dockerfile) |
+| Debian 8 | 4.03.0 | 1.2.2 | `docker pull akabe/ocaml:debian8_ocaml4.03.0` | [Dockerfile](dockerfiles/debian8_ocaml4.03.0/Dockerfile) |
+| Debian 8 | 4.02.3 | 1.2.2 | `docker pull akabe/ocaml:debian8_ocaml4.02.3` | [Dockerfile](dockerfiles/debian8_ocaml4.02.3/Dockerfile) |
+| Debian 8 | 4.01.0 | 1.2.2 | `docker pull akabe/ocaml:debian8_ocaml4.01.0` | [Dockerfile](dockerfiles/debian8_ocaml4.01.0/Dockerfile) |
+| Debian 8 | 4.00.1 | 1.2.2 | `docker pull akabe/ocaml:debian8_ocaml4.00.1` | [Dockerfile](dockerfiles/debian8_ocaml4.00.1/Dockerfile) |
 
 ### Ubuntu
 
-| Distribution | OCaml | OPAM | Command |
-| ------------ | ----- | ---- | ------- |
-| Ubuntu 16.04 | 4.06.0+trunk | 1.2.2 | `docker pull akabe/ocaml:ubuntu16.04_ocaml4.06.0` |
-| Ubuntu 16.04 | 4.05.0+trunk | 1.2.2 | `docker pull akabe/ocaml:ubuntu16.04_ocaml4.05.0` |
-| Ubuntu 16.04 | 4.04.1 | 1.2.2 | `docker pull akabe/ocaml:ubuntu16.04_ocaml4.04.1` |
-| Ubuntu 16.04 | 4.03.0 | 1.2.2 | `docker pull akabe/ocaml:ubuntu16.04_ocaml4.03.0` |
-| Ubuntu 16.04 | 4.02.3 | 1.2.2 | `docker pull akabe/ocaml:ubuntu16.04_ocaml4.02.3` |
-| Ubuntu 16.04 | 4.01.0 | 1.2.2 | `docker pull akabe/ocaml:ubuntu16.04_ocaml4.01.0` |
-| Ubuntu 16.04 | 4.00.1 | 1.2.2 | `docker pull akabe/ocaml:ubuntu16.04_ocaml4.00.1` |
+| Distribution | OCaml | OPAM | Command | Dockerfile |
+| ------------ | ----- | ---- | ------- | ---------- |
+| Ubuntu | 4.06.0+trunk | 1.2.2 | `docker pull akabe/ocaml:ubuntu_ocaml4.06.0` | [Dockerfile](dockerfiles/ubuntu16.04_ocaml4.06.0/Dockerfile) |
+| Ubuntu | 4.05.0+trunk | 1.2.2 | `docker pull akabe/ocaml:ubuntu_ocaml4.05.0` | [Dockerfile](dockerfiles/ubuntu16.04_ocaml4.05.0/Dockerfile) |
+| Ubuntu | 4.04.1 | 1.2.2 | `docker pull akabe/ocaml:ubuntu_ocaml4.04.1` | [Dockerfile](dockerfiles/ubuntu16.04_ocaml4.04.1/Dockerfile) |
+| Ubuntu | 4.03.0 | 1.2.2 | `docker pull akabe/ocaml:ubuntu_ocaml4.03.0` | [Dockerfile](dockerfiles/ubuntu16.04_ocaml4.03.0/Dockerfile) |
+| Ubuntu | 4.02.3 | 1.2.2 | `docker pull akabe/ocaml:ubuntu_ocaml4.02.3` | [Dockerfile](dockerfiles/ubuntu16.04_ocaml4.02.3/Dockerfile) |
+| Ubuntu | 4.01.0 | 1.2.2 | `docker pull akabe/ocaml:ubuntu_ocaml4.01.0` | [Dockerfile](dockerfiles/ubuntu16.04_ocaml4.01.0/Dockerfile) |
+| Ubuntu | 4.00.1 | 1.2.2 | `docker pull akabe/ocaml:ubuntu_ocaml4.00.1` | [Dockerfile](dockerfiles/ubuntu16.04_ocaml4.00.1/Dockerfile) |
+| Ubuntu 16.04 | 4.06.0+trunk | 1.2.2 | `docker pull akabe/ocaml:ubuntu16.04_ocaml4.06.0` | [Dockerfile](dockerfiles/ubuntu16.04_ocaml4.06.0/Dockerfile) |
+| Ubuntu 16.04 | 4.05.0+trunk | 1.2.2 | `docker pull akabe/ocaml:ubuntu16.04_ocaml4.05.0` | [Dockerfile](dockerfiles/ubuntu16.04_ocaml4.05.0/Dockerfile) |
+| Ubuntu 16.04 | 4.04.1 | 1.2.2 | `docker pull akabe/ocaml:ubuntu16.04_ocaml4.04.1` | [Dockerfile](dockerfiles/ubuntu16.04_ocaml4.04.1/Dockerfile) |
+| Ubuntu 16.04 | 4.03.0 | 1.2.2 | `docker pull akabe/ocaml:ubuntu16.04_ocaml4.03.0` | [Dockerfile](dockerfiles/ubuntu16.04_ocaml4.03.0/Dockerfile) |
+| Ubuntu 16.04 | 4.02.3 | 1.2.2 | `docker pull akabe/ocaml:ubuntu16.04_ocaml4.02.3` | [Dockerfile](dockerfiles/ubuntu16.04_ocaml4.02.3/Dockerfile) |
+| Ubuntu 16.04 | 4.01.0 | 1.2.2 | `docker pull akabe/ocaml:ubuntu16.04_ocaml4.01.0` | [Dockerfile](dockerfiles/ubuntu16.04_ocaml4.01.0/Dockerfile) |
+| Ubuntu 16.04 | 4.00.1 | 1.2.2 | `docker pull akabe/ocaml:ubuntu16.04_ocaml4.00.1` | [Dockerfile](dockerfiles/ubuntu16.04_ocaml4.00.1/Dockerfile) |

--- a/dockerfiles/alpine3.5_ocaml4.00.1/Dockerfile
+++ b/dockerfiles/alpine3.5_ocaml4.00.1/Dockerfile
@@ -1,0 +1,33 @@
+FROM alpine:3.5
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.00.1
+ENV HOME          /home/opam
+
+RUN mkdir /lib64 && \
+    ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 && \
+    \
+    apk update && \
+    apk upgrade && \
+    apk add --upgrade --no-cache sudo make patch musl libx11 && \
+    apk add --upgrade --no-cache --virtual .build-dependencies \
+            curl gcc musl-dev libx11-dev && \
+    \
+    adduser -h $HOME -s /bin/sh -D opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apk del .build-dependencies
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "sh" ]

--- a/dockerfiles/alpine3.5_ocaml4.01.0/Dockerfile
+++ b/dockerfiles/alpine3.5_ocaml4.01.0/Dockerfile
@@ -1,0 +1,33 @@
+FROM alpine:3.5
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.01.0
+ENV HOME          /home/opam
+
+RUN mkdir /lib64 && \
+    ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 && \
+    \
+    apk update && \
+    apk upgrade && \
+    apk add --upgrade --no-cache sudo make patch musl libx11 && \
+    apk add --upgrade --no-cache --virtual .build-dependencies \
+            curl gcc musl-dev libx11-dev && \
+    \
+    adduser -h $HOME -s /bin/sh -D opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apk del .build-dependencies
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "sh" ]

--- a/dockerfiles/alpine3.5_ocaml4.02.3/Dockerfile
+++ b/dockerfiles/alpine3.5_ocaml4.02.3/Dockerfile
@@ -1,0 +1,33 @@
+FROM alpine:3.5
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.02.3
+ENV HOME          /home/opam
+
+RUN mkdir /lib64 && \
+    ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 && \
+    \
+    apk update && \
+    apk upgrade && \
+    apk add --upgrade --no-cache sudo make patch musl libx11 && \
+    apk add --upgrade --no-cache --virtual .build-dependencies \
+            curl gcc musl-dev libx11-dev && \
+    \
+    adduser -h $HOME -s /bin/sh -D opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apk del .build-dependencies
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "sh" ]

--- a/dockerfiles/alpine3.5_ocaml4.03.0/Dockerfile
+++ b/dockerfiles/alpine3.5_ocaml4.03.0/Dockerfile
@@ -1,0 +1,33 @@
+FROM alpine:3.5
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.03.0
+ENV HOME          /home/opam
+
+RUN mkdir /lib64 && \
+    ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 && \
+    \
+    apk update && \
+    apk upgrade && \
+    apk add --upgrade --no-cache sudo make patch musl libx11 && \
+    apk add --upgrade --no-cache --virtual .build-dependencies \
+            curl gcc musl-dev libx11-dev && \
+    \
+    adduser -h $HOME -s /bin/sh -D opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apk del .build-dependencies
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "sh" ]

--- a/dockerfiles/alpine3.5_ocaml4.04.1/Dockerfile
+++ b/dockerfiles/alpine3.5_ocaml4.04.1/Dockerfile
@@ -1,0 +1,33 @@
+FROM alpine:3.5
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.04.1
+ENV HOME          /home/opam
+
+RUN mkdir /lib64 && \
+    ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 && \
+    \
+    apk update && \
+    apk upgrade && \
+    apk add --upgrade --no-cache sudo make patch musl libx11 && \
+    apk add --upgrade --no-cache --virtual .build-dependencies \
+            curl gcc musl-dev libx11-dev && \
+    \
+    adduser -h $HOME -s /bin/sh -D opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apk del .build-dependencies
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "sh" ]

--- a/dockerfiles/alpine3.5_ocaml4.05.0/Dockerfile
+++ b/dockerfiles/alpine3.5_ocaml4.05.0/Dockerfile
@@ -1,0 +1,33 @@
+FROM alpine:3.5
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.05.0+trunk
+ENV HOME          /home/opam
+
+RUN mkdir /lib64 && \
+    ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 && \
+    \
+    apk update && \
+    apk upgrade && \
+    apk add --upgrade --no-cache sudo make patch musl libx11 && \
+    apk add --upgrade --no-cache --virtual .build-dependencies \
+            curl gcc musl-dev libx11-dev && \
+    \
+    adduser -h $HOME -s /bin/sh -D opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apk del .build-dependencies
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "sh" ]

--- a/dockerfiles/alpine3.5_ocaml4.06.0/Dockerfile
+++ b/dockerfiles/alpine3.5_ocaml4.06.0/Dockerfile
@@ -1,0 +1,33 @@
+FROM alpine:3.5
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.06.0+trunk
+ENV HOME          /home/opam
+
+RUN mkdir /lib64 && \
+    ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 && \
+    \
+    apk update && \
+    apk upgrade && \
+    apk add --upgrade --no-cache sudo make patch musl libx11 && \
+    apk add --upgrade --no-cache --virtual .build-dependencies \
+            curl gcc musl-dev libx11-dev && \
+    \
+    adduser -h $HOME -s /bin/sh -D opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apk del .build-dependencies
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "sh" ]

--- a/dockerfiles/centos6_ocaml4.00.1/Dockerfile
+++ b/dockerfiles/centos6_ocaml4.00.1/Dockerfile
@@ -1,0 +1,30 @@
+FROM centos:6
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.00.1
+ENV HOME          /home/opam
+
+RUN yum update -y && \
+    yum install -y sudo patch unzip make libx11 \
+                   libx11-devel gcc && \
+    yum clean all && \
+    \
+    adduser --home-dir $HOME --shell /bin/bash opam && \
+    passwd -d opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    yum remove libx11-devel gcc
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/centos6_ocaml4.01.0/Dockerfile
+++ b/dockerfiles/centos6_ocaml4.01.0/Dockerfile
@@ -1,0 +1,30 @@
+FROM centos:6
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.01.0
+ENV HOME          /home/opam
+
+RUN yum update -y && \
+    yum install -y sudo patch unzip make libx11 \
+                   libx11-devel gcc && \
+    yum clean all && \
+    \
+    adduser --home-dir $HOME --shell /bin/bash opam && \
+    passwd -d opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    yum remove libx11-devel gcc
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/centos6_ocaml4.02.3/Dockerfile
+++ b/dockerfiles/centos6_ocaml4.02.3/Dockerfile
@@ -1,0 +1,30 @@
+FROM centos:6
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.02.3
+ENV HOME          /home/opam
+
+RUN yum update -y && \
+    yum install -y sudo patch unzip make libx11 \
+                   libx11-devel gcc && \
+    yum clean all && \
+    \
+    adduser --home-dir $HOME --shell /bin/bash opam && \
+    passwd -d opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    yum remove libx11-devel gcc
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/centos6_ocaml4.03.0/Dockerfile
+++ b/dockerfiles/centos6_ocaml4.03.0/Dockerfile
@@ -1,0 +1,30 @@
+FROM centos:6
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.03.0
+ENV HOME          /home/opam
+
+RUN yum update -y && \
+    yum install -y sudo patch unzip make libx11 \
+                   libx11-devel gcc && \
+    yum clean all && \
+    \
+    adduser --home-dir $HOME --shell /bin/bash opam && \
+    passwd -d opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    yum remove libx11-devel gcc
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/centos6_ocaml4.04.1/Dockerfile
+++ b/dockerfiles/centos6_ocaml4.04.1/Dockerfile
@@ -1,0 +1,30 @@
+FROM centos:6
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.04.1
+ENV HOME          /home/opam
+
+RUN yum update -y && \
+    yum install -y sudo patch unzip make libx11 \
+                   libx11-devel gcc && \
+    yum clean all && \
+    \
+    adduser --home-dir $HOME --shell /bin/bash opam && \
+    passwd -d opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    yum remove libx11-devel gcc
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/centos6_ocaml4.05.0/Dockerfile
+++ b/dockerfiles/centos6_ocaml4.05.0/Dockerfile
@@ -1,0 +1,30 @@
+FROM centos:6
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.05.0+trunk
+ENV HOME          /home/opam
+
+RUN yum update -y && \
+    yum install -y sudo patch unzip make libx11 \
+                   libx11-devel gcc && \
+    yum clean all && \
+    \
+    adduser --home-dir $HOME --shell /bin/bash opam && \
+    passwd -d opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    yum remove libx11-devel gcc
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/centos6_ocaml4.06.0/Dockerfile
+++ b/dockerfiles/centos6_ocaml4.06.0/Dockerfile
@@ -1,0 +1,30 @@
+FROM centos:6
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.06.0+trunk
+ENV HOME          /home/opam
+
+RUN yum update -y && \
+    yum install -y sudo patch unzip make libx11 \
+                   libx11-devel gcc && \
+    yum clean all && \
+    \
+    adduser --home-dir $HOME --shell /bin/bash opam && \
+    passwd -d opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    yum remove libx11-devel gcc
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/centos7_ocaml4.00.1/Dockerfile
+++ b/dockerfiles/centos7_ocaml4.00.1/Dockerfile
@@ -1,0 +1,30 @@
+FROM centos:7
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.00.1
+ENV HOME          /home/opam
+
+RUN yum update -y && \
+    yum install -y sudo patch unzip make libx11 \
+                   libx11-devel gcc && \
+    yum clean all && \
+    \
+    adduser --home-dir $HOME --shell /bin/bash opam && \
+    passwd -d opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    yum remove libx11-devel gcc
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/centos7_ocaml4.01.0/Dockerfile
+++ b/dockerfiles/centos7_ocaml4.01.0/Dockerfile
@@ -1,0 +1,30 @@
+FROM centos:7
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.01.0
+ENV HOME          /home/opam
+
+RUN yum update -y && \
+    yum install -y sudo patch unzip make libx11 \
+                   libx11-devel gcc && \
+    yum clean all && \
+    \
+    adduser --home-dir $HOME --shell /bin/bash opam && \
+    passwd -d opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    yum remove libx11-devel gcc
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/centos7_ocaml4.02.3/Dockerfile
+++ b/dockerfiles/centos7_ocaml4.02.3/Dockerfile
@@ -1,0 +1,30 @@
+FROM centos:7
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.02.3
+ENV HOME          /home/opam
+
+RUN yum update -y && \
+    yum install -y sudo patch unzip make libx11 \
+                   libx11-devel gcc && \
+    yum clean all && \
+    \
+    adduser --home-dir $HOME --shell /bin/bash opam && \
+    passwd -d opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    yum remove libx11-devel gcc
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/centos7_ocaml4.03.0/Dockerfile
+++ b/dockerfiles/centos7_ocaml4.03.0/Dockerfile
@@ -1,0 +1,30 @@
+FROM centos:7
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.03.0
+ENV HOME          /home/opam
+
+RUN yum update -y && \
+    yum install -y sudo patch unzip make libx11 \
+                   libx11-devel gcc && \
+    yum clean all && \
+    \
+    adduser --home-dir $HOME --shell /bin/bash opam && \
+    passwd -d opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    yum remove libx11-devel gcc
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/centos7_ocaml4.04.1/Dockerfile
+++ b/dockerfiles/centos7_ocaml4.04.1/Dockerfile
@@ -1,0 +1,30 @@
+FROM centos:7
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.04.1
+ENV HOME          /home/opam
+
+RUN yum update -y && \
+    yum install -y sudo patch unzip make libx11 \
+                   libx11-devel gcc && \
+    yum clean all && \
+    \
+    adduser --home-dir $HOME --shell /bin/bash opam && \
+    passwd -d opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    yum remove libx11-devel gcc
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/centos7_ocaml4.05.0/Dockerfile
+++ b/dockerfiles/centos7_ocaml4.05.0/Dockerfile
@@ -1,0 +1,30 @@
+FROM centos:7
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.05.0+trunk
+ENV HOME          /home/opam
+
+RUN yum update -y && \
+    yum install -y sudo patch unzip make libx11 \
+                   libx11-devel gcc && \
+    yum clean all && \
+    \
+    adduser --home-dir $HOME --shell /bin/bash opam && \
+    passwd -d opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    yum remove libx11-devel gcc
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/centos7_ocaml4.06.0/Dockerfile
+++ b/dockerfiles/centos7_ocaml4.06.0/Dockerfile
@@ -1,0 +1,30 @@
+FROM centos:7
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.06.0+trunk
+ENV HOME          /home/opam
+
+RUN yum update -y && \
+    yum install -y sudo patch unzip make libx11 \
+                   libx11-devel gcc && \
+    yum clean all && \
+    \
+    adduser --home-dir $HOME --shell /bin/bash opam && \
+    passwd -d opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    yum remove libx11-devel gcc
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/debian8_ocaml4.00.1/Dockerfile
+++ b/dockerfiles/debian8_ocaml4.00.1/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:8
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.00.1
+ENV HOME          /home/opam
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y sudo patch unzip make libx11-6 \
+                       curl gcc libx11-dev && \
+    \
+    adduser --disabled-password --home $HOME --shell /bin/bash --gecos '' opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apt-get purge curl gcc libx11-dev && \
+    apt-get autoremove && \
+    apt-get autoclean
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/debian8_ocaml4.01.0/Dockerfile
+++ b/dockerfiles/debian8_ocaml4.01.0/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:8
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.01.0
+ENV HOME          /home/opam
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y sudo patch unzip make libx11-6 \
+                       curl gcc libx11-dev && \
+    \
+    adduser --disabled-password --home $HOME --shell /bin/bash --gecos '' opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apt-get purge curl gcc libx11-dev && \
+    apt-get autoremove && \
+    apt-get autoclean
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/debian8_ocaml4.02.3/Dockerfile
+++ b/dockerfiles/debian8_ocaml4.02.3/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:8
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.02.3
+ENV HOME          /home/opam
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y sudo patch unzip make libx11-6 \
+                       curl gcc libx11-dev && \
+    \
+    adduser --disabled-password --home $HOME --shell /bin/bash --gecos '' opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apt-get purge curl gcc libx11-dev && \
+    apt-get autoremove && \
+    apt-get autoclean
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/debian8_ocaml4.03.0/Dockerfile
+++ b/dockerfiles/debian8_ocaml4.03.0/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:8
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.03.0
+ENV HOME          /home/opam
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y sudo patch unzip make libx11-6 \
+                       curl gcc libx11-dev && \
+    \
+    adduser --disabled-password --home $HOME --shell /bin/bash --gecos '' opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apt-get purge curl gcc libx11-dev && \
+    apt-get autoremove && \
+    apt-get autoclean
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/debian8_ocaml4.04.1/Dockerfile
+++ b/dockerfiles/debian8_ocaml4.04.1/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:8
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.04.1
+ENV HOME          /home/opam
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y sudo patch unzip make libx11-6 \
+                       curl gcc libx11-dev && \
+    \
+    adduser --disabled-password --home $HOME --shell /bin/bash --gecos '' opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apt-get purge curl gcc libx11-dev && \
+    apt-get autoremove && \
+    apt-get autoclean
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/debian8_ocaml4.05.0/Dockerfile
+++ b/dockerfiles/debian8_ocaml4.05.0/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:8
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.05.0+trunk
+ENV HOME          /home/opam
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y sudo patch unzip make libx11-6 \
+                       curl gcc libx11-dev && \
+    \
+    adduser --disabled-password --home $HOME --shell /bin/bash --gecos '' opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apt-get purge curl gcc libx11-dev && \
+    apt-get autoremove && \
+    apt-get autoclean
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/debian8_ocaml4.06.0/Dockerfile
+++ b/dockerfiles/debian8_ocaml4.06.0/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:8
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.06.0+trunk
+ENV HOME          /home/opam
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y sudo patch unzip make libx11-6 \
+                       curl gcc libx11-dev && \
+    \
+    adduser --disabled-password --home $HOME --shell /bin/bash --gecos '' opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apt-get purge curl gcc libx11-dev && \
+    apt-get autoremove && \
+    apt-get autoclean
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/ubuntu16.04_ocaml4.00.1/Dockerfile
+++ b/dockerfiles/ubuntu16.04_ocaml4.00.1/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:16.04
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.00.1
+ENV HOME          /home/opam
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y sudo patch unzip make libx11-6 \
+                       curl gcc libx11-dev && \
+    \
+    adduser --disabled-password --home $HOME --shell /bin/bash --gecos '' opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apt-get purge curl gcc libx11-dev && \
+    apt-get autoremove && \
+    apt-get autoclean
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/ubuntu16.04_ocaml4.01.0/Dockerfile
+++ b/dockerfiles/ubuntu16.04_ocaml4.01.0/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:16.04
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.01.0
+ENV HOME          /home/opam
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y sudo patch unzip make libx11-6 \
+                       curl gcc libx11-dev && \
+    \
+    adduser --disabled-password --home $HOME --shell /bin/bash --gecos '' opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apt-get purge curl gcc libx11-dev && \
+    apt-get autoremove && \
+    apt-get autoclean
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/ubuntu16.04_ocaml4.02.3/Dockerfile
+++ b/dockerfiles/ubuntu16.04_ocaml4.02.3/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:16.04
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.02.3
+ENV HOME          /home/opam
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y sudo patch unzip make libx11-6 \
+                       curl gcc libx11-dev && \
+    \
+    adduser --disabled-password --home $HOME --shell /bin/bash --gecos '' opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apt-get purge curl gcc libx11-dev && \
+    apt-get autoremove && \
+    apt-get autoclean
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/ubuntu16.04_ocaml4.03.0/Dockerfile
+++ b/dockerfiles/ubuntu16.04_ocaml4.03.0/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:16.04
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.03.0
+ENV HOME          /home/opam
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y sudo patch unzip make libx11-6 \
+                       curl gcc libx11-dev && \
+    \
+    adduser --disabled-password --home $HOME --shell /bin/bash --gecos '' opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apt-get purge curl gcc libx11-dev && \
+    apt-get autoremove && \
+    apt-get autoclean
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/ubuntu16.04_ocaml4.04.1/Dockerfile
+++ b/dockerfiles/ubuntu16.04_ocaml4.04.1/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:16.04
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.04.1
+ENV HOME          /home/opam
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y sudo patch unzip make libx11-6 \
+                       curl gcc libx11-dev && \
+    \
+    adduser --disabled-password --home $HOME --shell /bin/bash --gecos '' opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apt-get purge curl gcc libx11-dev && \
+    apt-get autoremove && \
+    apt-get autoclean
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/ubuntu16.04_ocaml4.05.0/Dockerfile
+++ b/dockerfiles/ubuntu16.04_ocaml4.05.0/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:16.04
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.05.0+trunk
+ENV HOME          /home/opam
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y sudo patch unzip make libx11-6 \
+                       curl gcc libx11-dev && \
+    \
+    adduser --disabled-password --home $HOME --shell /bin/bash --gecos '' opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apt-get purge curl gcc libx11-dev && \
+    apt-get autoremove && \
+    apt-get autoclean
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/dockerfiles/ubuntu16.04_ocaml4.06.0/Dockerfile
+++ b/dockerfiles/ubuntu16.04_ocaml4.06.0/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:16.04
+
+ENV OPAM_VERSION  1.2.2
+ENV OCAML_VERSION 4.06.0+trunk
+ENV HOME          /home/opam
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y sudo patch unzip make libx11-6 \
+                       curl gcc libx11-dev && \
+    \
+    adduser --disabled-password --home $HOME --shell /bin/bash --gecos '' opam && \
+    \
+    echo 'opam ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && \
+    curl -L -o /usr/bin/opam "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" && \
+    chmod 755 /usr/bin/opam && \
+    su opam -c "opam init -a -y --comp $OCAML_VERSION" && \
+    \
+    find $HOME/.opam -regex '.*\\.\\(cmt\\|cmti\\|annot\\|byte\\)' -delete && \
+    rm -rf $HOME/.opam/archives \
+           $HOME/.opam/repo/default/archives \
+           $HOME/.opam/$OCAML_VERSION/build \
+    \
+    apt-get purge curl gcc libx11-dev && \
+    apt-get autoremove && \
+    apt-get autoclean
+
+USER opam
+WORKDIR $HOME
+ENTRYPOINT [ "opam", "config", "exec", "--" ]
+CMD [ "bash" ]

--- a/generate.sh
+++ b/generate.sh
@@ -66,7 +66,11 @@ $(opam_ocaml_scripts) \\
 EOF
 }
 
-cat <<EOF
+echo "Generating dockerfiles/$TAG/Dockerfile (ALIAS=${ALIAS[@]})..."
+
+mkdir -p dockerfiles/$TAG
+
+cat <<EOF > dockerfiles/$TAG/Dockerfile
 FROM ${OS}
 
 ENV OPAM_VERSION  ${OPAM}
@@ -76,26 +80,26 @@ ENV HOME          /home/opam
 EOF
 
 if [[ "$OS" =~ ^alpine: ]]; then
-    alpine_scripts
+    alpine_scripts >> dockerfiles/$TAG/Dockerfile
     SHELL=sh
 elif [[ "$OS" =~ ^centos: ]]; then
-    centos_scripts
+    centos_scripts >> dockerfiles/$TAG/Dockerfile
     SHELL=bash
 elif [[ "$OS" =~ ^debian: ]]; then
-    debian_scripts
+    debian_scripts >> dockerfiles/$TAG/Dockerfile
     SHELL=bash
 elif [[ "$OS" =~ ^ubuntu: ]]; then
-    debian_scripts
+    debian_scripts >> dockerfiles/$TAG/Dockerfile
     SHELL=bash
 else
     echo -e "\033[31m[ERROR] Unknown base image: ${OS}\033[0m"
     exit 1
 fi
 
-cat <<EOF
+cat <<EOF >> dockerfiles/$TAG/Dockerfile
 
 USER opam
-WORKDIR $HOME
+WORKDIR \$HOME
 ENTRYPOINT [ "opam", "config", "exec", "--" ]
 CMD [ "${SHELL}" ]
 EOF

--- a/generate_all.sh
+++ b/generate_all.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -eu
+
+sed -ne 's/ *- \(TAG.*\)$/\1/p' .travis.yml | while read -r env; do
+    eval "$env"
+    source ./generate.sh
+done

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -1,0 +1,90 @@
+#!/bin/bash -ue
+
+function red_echo() {
+    echo -e "\033[31m$@\033[0m"
+}
+
+function green_echo() {
+    echo -e "\033[32m$@\033[0m"
+}
+
+function yellow_echo() {
+    echo -e "\033[33m$@\033[0m"
+}
+
+function check_unpushed_changes() {
+    source ./generate.sh # Update Dockerfile
+
+    if git diff --name-only HEAD | grep "^dockerfiles/$TAG" >/dev/null; then
+	red_echo "[ERROR] Changes for tag $TAG are not uncommited or unpushed."
+	red_echo "        ./generate_all.sh and push the changes"
+	git diff HEAD
+	exit 127
+    fi
+}
+
+## Print the difference of this pull request into STDOUT.
+function git_diff_pullreq() {
+    yellow_echo "Pull request: $TRAVIS_PULL_REQUEST" >&2
+
+    if [[ "$TRAVIS_PULL_REQUEST" != false ]]; then
+	curl -sL https://github.com/$TRAVIS_REPO_SLUG/pull/$TRAVIS_PULL_REQUEST.diff
+    else
+	local merge
+	merge=$(git show | grep '^Merge: ' | awk '{print $2 ".." $3}')
+	if [[ "$merge" == '' ]]; then
+	    yellow_echo "The latest commit is not a merge." >&2
+	    git show
+	else
+	    yellow_echo "The latest commit is a merge: $merge" >&2
+	    git diff $merge
+	fi
+    fi
+}
+
+function build_image() {
+    yellow_echo "[Build] $TAG: Dockerfile is changed."
+
+    docker build -t akabe/ocaml:$TAG dockerfiles/$TAG
+    docker history akabe/ocaml:$TAG
+}
+
+function test_image() {
+    yellow_echo "[Test] $TAG"
+
+    docker run --rm -v $PWD:$PWD -w $PWD/tests akabe/ocaml:$TAG sh run_test.sh
+}
+
+function deploy_image() {
+    if [[ "$TRAVIS_PULL_REQUEST" == false ]] && [[ "$TRAVIS_BRANCH" == master ]]; then
+	yellow_echo "[Deploy] Deploy image tag $TAG"
+
+	docker login -u $DOCKER_USER -p $DOCKER_PWD
+	docker push akabe/ocaml:$TAG
+
+	for t in $ALIAS; do
+	    yellow_echo "[Deploy] Deploy image tag $TAG as $t"
+	    docker tag akabe/ocaml:$TAG akabe/ocaml:$t
+	    docker push akabe/ocaml:$t
+	done
+    else
+    	yellow_echo "[Deploy] Skip pushing image tag $TAG..."
+
+    	for t in $ALIAS; do
+    	    yellow_echo "[Deploy] Skip pushing image tag $t"
+    	done
+    fi
+}
+
+check_unpushed_changes
+
+git_diff_pullreq > pullreq.diff
+cat pullreq.diff
+
+if grep "^+++ b/dockerfiles/$TAG/Dockerfile" pullreq.diff >/dev/null; then
+    build_image
+    test_image
+    deploy_image
+else
+    green_echo "[ OK ] $TAG: Dockerfile is not changed."
+fi


### PR DESCRIPTION
Travis CI is slow due to building too many images...
Only changed images should be built and unchanged Dockerfiles need to be ignored.